### PR TITLE
Migrate to collectd baseami and make use of ebslvm

### DIFF
--- a/build/config.json
+++ b/build/config.json
@@ -1,7 +1,7 @@
 {
   "name": "spade_edge",
   "creds": "~/.aws",
-  "baseami": "ami-71a6d841",
+  "baseami": "ami-9b1158ab",
   "stages": {
     "build": "./build/gobuild.sh",
     "test": "./build/gotest.sh",

--- a/build/config/mount_ebslvm.conf
+++ b/build/config/mount_ebslvm.conf
@@ -1,0 +1,10 @@
+# upstart file to mount volume
+
+start on filesystem
+
+emits ebslvm-mounted
+
+script
+  /usr/sbin/ebslvm vgebs lvebs /mnt
+  initctl emit ebslvm-mounted
+end script

--- a/build/config/upstart.conf
+++ b/build/config/upstart.conf
@@ -1,9 +1,11 @@
 # Upstart script at /etc/init/spade_edge.conf
 
-start on runlevel [2345]
+start on ebslvm-mounted
 # supposedly this will cause the system to hang shutdown on
 # upstart killing the edge: http://goo.gl/lJQVzH
 stop on starting rc RUNLEVEL=[016]
+
+emits edge-running
 
 respawn
 respawn limit 10 5
@@ -13,6 +15,6 @@ kill signal SIGINT
 
 script
   exec /opt/science/spade_edge/bin/run_edge.sh
-  emit edge_running
+  initctl emit edge-running
 end script
 

--- a/build/finalize.sh
+++ b/build/finalize.sh
@@ -12,4 +12,5 @@ mv ${PKGDIR}/deploy ${EDGEDIR}
 chmod +x ${EDGEDIR}/bin/*
 
 # Setup upstart
+mv ${CONFDIR}/mount_ebslvm.conf ${UPSTARTDIR}/mount_ebslvm.conf
 mv ${CONFDIR}/upstart.conf ${UPSTARTDIR}/spade_edge.conf


### PR DESCRIPTION
This new baseami includes collectd logging to our hostedgraphite
instance. This'll permit us to monitor system level stats on our edge
tier.

Additionally we're now writing to an lvm which spans two ebs volumes,
which in theory should give us more reliable write performance. Though
there is a follow up task to ensure we're launching EBS-optimized
instances (which isn't currently the case).

I have tested this in the integration cluster; I can confirm that spade_edge starts.
